### PR TITLE
segunda otimização de código

### DIFF
--- a/Assets/Scenes/FaseTutorial.unity
+++ b/Assets/Scenes/FaseTutorial.unity
@@ -3699,12 +3699,12 @@ Prefab:
     - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
         type: 2}
       propertyPath: minPosition
-      value: -54
+      value: -50
       objectReference: {fileID: 0}
     - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
         type: 2}
       propertyPath: maxPosition
-      value: -20
+      value: -27
       objectReference: {fileID: 0}
     - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
         type: 2}
@@ -3714,7 +3714,17 @@ Prefab:
     - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
         type: 2}
       propertyPath: delay
-      value: 10
+      value: 40
+      objectReference: {fileID: 0}
+    - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
+        type: 2}
+      propertyPath: minAngle
+      value: 320
+      objectReference: {fileID: 0}
+    - target: {fileID: 114078831863334670, guid: bc3ca840e4a8d4233a32866199195ed3,
+        type: 2}
+      propertyPath: maxAngle
+      value: 400
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_ParentPrefab: {fileID: 100100000, guid: bc3ca840e4a8d4233a32866199195ed3, type: 2}

--- a/Assets/Scripts/Particles Scripts/Particle.cs
+++ b/Assets/Scripts/Particles Scripts/Particle.cs
@@ -52,15 +52,14 @@ public class Particle : MonoBehaviour {
 
 	void Start () {
 		initialPosition = transform.position;
-		TrailRenderer tr = GetComponent<TrailRenderer> ();
-		tr.sortingLayerName = TrSortingLayer;
+		tail = GetComponent<TrailRenderer> ();
+		tail.sortingLayerName = TrSortingLayer;
 
 		trans = transform;
 		pos = trans.position;
 		rot = trans.rotation.eulerAngles;
 
 		sr = GetComponent<SpriteRenderer> ();
-		tail = GetComponent<TrailRenderer> ();
 
 		if (GetComponent<ParticleSystem> () != null) {
 			ps = GetComponent<ParticleSystem> ();
@@ -161,5 +160,17 @@ public class Particle : MonoBehaviour {
 			destroyParticle ();
 		}
 	}
-
+	void OnDestroy(){
+		tail = null;
+		for (int i = 0; i < daughters.Length; i++) {
+			daughters [i] = null;
+		}
+		daughters = null;
+		ps = null;
+		sr = null;
+		particleRipple = null;
+		particleRippleD = null;
+		trans = null;
+		rb = null;
+	}
 }

--- a/Assets/Scripts/Particles Scripts/ParticleGenerator.cs
+++ b/Assets/Scripts/Particles Scripts/ParticleGenerator.cs
@@ -82,4 +82,11 @@ public class ParticleGenerator : MonoBehaviour {
 	void RandomPosition () {
 		generatePoint.position = new Vector3 (Random.Range (minPosition, maxPosition), generatePoint.position.y, generatePoint.position.z);
 	}
+	void OnDestroy(){
+		generatePoint = null;
+		for (int i = 0; i < particles.Length; i++) {
+			particles [i] = null;
+		}
+		particles = null;
+	}
 }

--- a/Assets/Scripts/SceneDataManager.cs
+++ b/Assets/Scripts/SceneDataManager.cs
@@ -139,6 +139,7 @@ public class SceneDataManager : MonoBehaviour {
 	}
 	void OnApplicationQuit () {
 		PlayerPrefs.DeleteAll ();
+		Resources.UnloadUnusedAssets ();
 	}
 
 	void OnDestroy () {
@@ -155,7 +156,6 @@ public class SceneDataManager : MonoBehaviour {
 			doors [i] = null;
 		}
 		doors = null;
-
 	}
 
 	public void Save () {


### PR DESCRIPTION
Após a finalização da fase tutorial, o projeto apresentou um grande vazamento de memório que acontecia da seguinte maneira: o unity usa 400MB, ao dar play e chegar na fase tutorial o unity chega a 1200MB, ao terminar a execução do jogo o unity continua com 1200MB de RAM. Esse vazamento acontecia porque as partículas contém muitas referências guardadas no Managed Domain que não eram desalocadas ao se destruírem as partículas, portanto utilizei o método OnDestroy() para apagar as referências pesadas (apontando para null). Isso deve ser feito em todos os nossos GameObjects que possuem scripts que referênciam demais. Assim o jogo usará a memória de maneira mais inteligente. Obrigado!